### PR TITLE
Add Dockerfile for service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml mvnw .
+COPY .mvn .mvn
+RUN chmod +x mvnw && ./mvnw dependency:go-offline
+COPY src src
+RUN ./mvnw package -DskipTests
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 7100
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
## Summary
- add Dockerfile exposing port 7100 for the Telegram service

## Testing
- `mvnw -q test` *(fails: Failed to fetch apache-maven due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68582f50b7a48324b97c17cabede8fd9